### PR TITLE
Extend user setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,12 @@ enable_rundeck: true
 enable_rundeck_plugins: true
 pri_domain_name: example.org
 rundeck_base: /var/lib/rundeck
+rundeck_ssh_generate_key: omit # uses Ansible defaults
 rundeck_ssh_keydir: './ssh_pub_keys/'
+rundeck_ssh_key_bits: omit # uses Ansible defaults
+rundeck_ssh_key_comment: omit # uses Ansible defaults
+rundeck_ssh_key_passphrase: omit # uses Ansible defaults
+rundeck_ssh_key_type: omit # uses Ansible defaults
 rundeck_configs:
   - 'framework.properties'
   - 'rundeck-config.properties'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,12 @@ enable_rundeck: true
 enable_rundeck_plugins: true
 pri_domain_name: 'example.org'
 rundeck_base: '/var/lib/rundeck'
+rundeck_ssh_generate_key: true
 rundeck_ssh_keydir: './ssh_pub_keys/'
+# rundeck_ssh_key_bits: 2048
+# rundeck_ssh_key_comment: 'ansible-generated on $HOSTNAME'
+# rundeck_ssh_key_passphrase: ''
+# rundeck_ssh_key_type: rsa
 rundeck_configs:
   - 'framework.properties'
   - 'rundeck-config.properties'

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -22,3 +22,4 @@
     src: "{{ rundeck_framework_ssh_keypath_file }}.pub"
     dest: "{{ rundeck_ssh_keydir }}/{{ rundeck_framework_ssh_user }}@{{ ansible_hostname }}.pub"
     flat: yes
+  when: rundeck_ssh_generate_key

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,9 +10,12 @@
 - name: users | generating rundeck ssh key
   user:
     name: "{{ rundeck_framework_ssh_user }}"
-    generate_ssh_key: yes
+    generate_ssh_key: "{{ rundeck_ssh_generate_key | default(omit) }}"
+    ssh_key_bits: "{{ rundeck_ssh_key_bits | default(omit) }}"
+    ssh_key_comment: "{{ rundeck_ssh_key_comment | default(omit) }}"
     ssh_key_file: "{{ rundeck_framework_ssh_keypath_file }}"
-    ssh_key_type: rsa
+    ssh_key_passphrase: "{{ rundeck_ssh_key_passphrase | default(omit) }}"
+    ssh_key_type: "{{ rundeck_ssh_key_type | default(omit) }}"
 
 - name: users | downloading rundeck users ssh public key
   fetch:

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,7 +10,7 @@
 - name: users | generating rundeck ssh key
   user:
     name: "{{ rundeck_framework_ssh_user }}"
-    generate_ssh_key: "{{ rundeck_ssh_generate_key | default(omit) }}"
+    generate_ssh_key: "{{ rundeck_ssh_generate_key }}"
     ssh_key_bits: "{{ rundeck_ssh_key_bits | default(omit) }}"
     ssh_key_comment: "{{ rundeck_ssh_key_comment | default(omit) }}"
     ssh_key_file: "{{ rundeck_framework_ssh_keypath_file }}"


### PR DESCRIPTION
Hello @mrlesmithjr,

this PR allows the user to control the SSH key setup more fine grained. Role behavior is same as before, but more options are available.

Let me know if you'd like to have changes on the PR.
