### PR TITLE
add config of simple users in realm.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ rundeck_auth_ldap_supplementalRoles: 'user'
 rundeck_auth_ldap_cacheDurationMillis: '300000'
 rundeck_auth_ldap_reportStatistics: 'true'
 rundeck_auth_ldap_nestedGroups: 'false'
+rundeck_users:
+  - name: peter
+    password: peterpass
+    roles: user
+    state: present # default, can be omitted
+  - name: 'marry'
+    password: marrypass
+    roles: 'user,admin'
+    state: absent
+  - name: 'karl'
+    password: "{{ rundeck_userpass_from_somewhere_else }}"
+    roles: 'user,admin'
 rundeck_install_ansible: true
 rundeck_logstash_host: []  #defines logstash server if used
 rundeck_logstash_port: 9700

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ rundeck_auth_ldap_supplementalRoles: 'user'
 rundeck_auth_ldap_cacheDurationMillis: '300000'
 rundeck_auth_ldap_reportStatistics: 'true'
 rundeck_auth_ldap_nestedGroups: 'false'
+rundeck_users: [] # defines users for PropertyFileLoginModule
 rundeck_install_ansible: true
 rundeck_logstash_host: []  #defines logstash server if used
 rundeck_logstash_port: 9700

--- a/tasks/config_rundeck.yml
+++ b/tasks/config_rundeck.yml
@@ -33,7 +33,7 @@
     dest: "{{ rundeck_root_dir }}/realm.properties"
     regexp: "^{{ item.item.name }}"
     line: "{{ item.item.name }}: MD5:{{ item.stdout }},{{ item.item.roles }}"
-    state: "{{ item.item.state | default(present) }}"
+    state: "{{ item.item.state | default('present') }}"
   with_items: "{{ rundeck_userhashes.results }}"
   when: rundeck_userhashes|success
   notify: restart rundeck

--- a/tasks/config_rundeck.yml
+++ b/tasks/config_rundeck.yml
@@ -20,3 +20,20 @@
     mode: 0640
   notify: restart rundeck
   when: rundeck_auth_ldap_config
+
+- name: config_rundeck | generate user password hashes for PropertyFileLoginModule
+  shell: echo -n {{ item.password }} | md5sum | cut -d' ' -f1
+  register: rundeck_userhashes
+  changed_when: false
+  when: rundeck_users
+  with_items: "{{ rundeck_users }}"
+
+- name: config_rundeck | add users to realm.properties
+  lineinfile:
+    dest: "{{ rundeck_root_dir }}/realm.properties"
+    regexp: "^{{ item.item.name }}"
+    line: "{{ item.item.name }}: MD5:{{ item.stdout }},{{ item.item.roles }}"
+    state: "{{ item.item.state | default(present) }}"
+  with_items: "{{ rundeck_userhashes.results }}"
+  when: rundeck_userhashes|success
+  notify: restart rundeck


### PR DESCRIPTION
Hello @mrlesmithjr,

here comes a PR which allows the user to configure (and remove) simple users in the realm.properties file. It also allows the user to change the default admin password.
Documentation was added in the knwon scheme.

Best

Jard