### PR TITLE
enable user to configure rundeck running behind ssl proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ rundeck_framework_server_username: 'admin'
 rundeck_framework_ssh_keypath_file: '{{ rundeck_framework_ssh_keypath }}/id_rsa'
 rundeck_framework_ssh_keypath: '/var/lib/rundeck/.ssh'
 rundeck_framework_ssh_user: 'rundeck'
+rundeck_grails_protocol: 'http'
+rundeck_grails_serverURL: "{{ ansible_fqdn }}"
+rundeck_grails_port: '4440'
+rundeck_jetty_connector_forwarded: false
 rundeck_auth_ldap_config: false
 rundeck_auth_ldap_debug: 'true'
 rundeck_auth_ldap_contextFactory: 'com.sun.jndi.ldap.LdapCtxFactory'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,10 @@ rundeck_framework_server_username: 'admin'
 rundeck_framework_ssh_keypath_file: '{{ rundeck_framework_ssh_keypath }}/id_rsa'
 rundeck_framework_ssh_keypath: '/var/lib/rundeck/.ssh'
 rundeck_framework_ssh_user: 'rundeck'
+rundeck_grails_protocol: 'http'
+rundeck_grails_serverURL: "{{ ansible_fqdn }}"
+rundeck_grails_port: '4440'
+rundeck_jetty_connector_forwarded: false
 rundeck_auth_ldap_config: false
 rundeck_auth_ldap_debug: 'true'
 rundeck_auth_ldap_contextFactory: 'com.sun.jndi.ldap.LdapCtxFactory'

--- a/templates/etc/rundeck/profile.j2
+++ b/templates/etc/rundeck/profile.j2
@@ -39,7 +39,7 @@ export RDECK_JVM="-Drdeck.config=/etc/rundeck \
     -Djava.security.auth.login.config=/etc/rundeck/jaas-loginmodule.conf \
     -Dloginmodule.name=RDpropertyfilelogin \
 {% endif %}
-{% if rundeck_jetty_connector_forwarded is defined %}
+{% if rundeck_jetty_connector_forwarded is defined and rundeck_jetty_connector_forwarded %}
     -Drundeck.jetty.connector.forwarded=true \
 {% endif %}
     -Djava.io.tmpdir=$RUNDECK_TEMPDIR"

--- a/templates/etc/rundeck/profile.j2
+++ b/templates/etc/rundeck/profile.j2
@@ -39,6 +39,9 @@ export RDECK_JVM="-Drdeck.config=/etc/rundeck \
     -Djava.security.auth.login.config=/etc/rundeck/jaas-loginmodule.conf \
     -Dloginmodule.name=RDpropertyfilelogin \
 {% endif %}
+{% if rundeck_jetty_connector_forwarded is defined %}
+    -Drundeck.jetty.connector.forwarded=true \
+{% endif %}
     -Djava.io.tmpdir=$RUNDECK_TEMPDIR"
 #
 # Set min/max heap size

--- a/templates/etc/rundeck/rundeck-config.properties.j2
+++ b/templates/etc/rundeck/rundeck-config.properties.j2
@@ -7,7 +7,7 @@ rdeck.base={{ rundeck_base }}
 rss.enabled=false
 # change hostname here
 {% if (rundeck_vagrant_install is defined and not rundeck_vagrant_install) or rundeck_vagrant_install is not defined %}
-grails.serverURL=http://{{ ansible_fqdn }}:4440
+grails.serverURL={{ rundeck_grails_protocol }}://{{ rundeck_grails_serverURL }}:{{ rundeck_grails_port }}
 {% elif rundeck_vagrant_install is defined and rundeck_vagrant_install %}
 grails.serverURL=http://127.0.0.1:4440
 {% endif %}


### PR DESCRIPTION
Hi,

after some days here come the next PR.
It allows some settings required to make Rundeck work behind and SSL proxy like Apache or NGINX.

[Rundeck documentation](http://rundeck.org/docs/administration/configuring-ssl.html)

Best
 
Jard
