### PR TITLE
allow user to configure static rundeck tokens file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ rundeck_grails_protocol: 'http'
 rundeck_grails_serverURL: "{{ ansible_fqdn }}"
 rundeck_grails_port: '4440'
 rundeck_jetty_connector_forwarded: false
+rundeck_framework_tokens_path: "{{ rundeck_root_dir }}"
+rundeck_framework_tokens_file: 'tokens.properties'
+# rundeck_framework_tokens:
+#  - user: admin
+#    key: myRKHyaGJOy5dt61cxyzHq9is0zpCKoq
+#  - user: deployer
+#    key: S2CbjdRgfADGbxnE4m3yx0xEUFSgVV2N
 rundeck_auth_ldap_config: false
 rundeck_auth_ldap_debug: 'true'
 rundeck_auth_ldap_contextFactory: 'com.sun.jndi.ldap.LdapCtxFactory'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,13 @@ rundeck_grails_protocol: 'http'
 rundeck_grails_serverURL: "{{ ansible_fqdn }}"
 rundeck_grails_port: '4440'
 rundeck_jetty_connector_forwarded: false
+rundeck_framework_tokens_path: "{{ rundeck_root_dir }}"
+rundeck_framework_tokens_file: 'tokens.properties'
+# rundeck_framework_tokens:
+#  - user: admin
+#    key: myRKHyaGJOy5dt61cxyzHq9is0zpCKoq
+#  - user: deployer
+#    key: S2CbjdRgfADGbxnE4m3yx0xEUFSgVV2N
 rundeck_auth_ldap_config: false
 rundeck_auth_ldap_debug: 'true'
 rundeck_auth_ldap_contextFactory: 'com.sun.jndi.ldap.LdapCtxFactory'

--- a/tasks/config_rundeck.yml
+++ b/tasks/config_rundeck.yml
@@ -37,3 +37,13 @@
   with_items: "{{ rundeck_userhashes.results }}"
   when: rundeck_userhashes|success
   notify: restart rundeck
+
+- name: config_rundeck | deploy static authentication tokens file
+  template:
+    src: "etc/rundeck/tokens.properties.j2"
+    dest: "{{ rundeck_framework_tokens_path }}/{{ rundeck_framework_tokens_file }}"
+    owner: "rundeck"
+    group: "rundeck"
+    mode: '0640'
+  notify: restart rundeck
+  when: rundeck_framework_tokens is defined and rundeck_framework_tokens

--- a/templates/etc/rundeck/framework.properties.j2
+++ b/templates/etc/rundeck/framework.properties.j2
@@ -42,3 +42,7 @@ framework.plugin.StreamingLogWriter.LogstashPlugin.port={{ rundeck_logstash_port
 framework.plugin.StreamingLogWriter.LogstashPlugin.host={{ rundeck_logstash_host }}
 {%   endif %}
 {% endif %}
+
+{% if rundeck_framework_tokens is defined and rundeck_framework_tokens %}
+rundeck.tokens.file={{ rundeck_framework_tokens_path }}/{{ rundeck_framework_tokens_file }}
+{% endif %}

--- a/templates/etc/rundeck/tokens.properties.j2
+++ b/templates/etc/rundeck/tokens.properties.j2
@@ -1,0 +1,5 @@
+{{ ansible_managed }}
+
+{% for pair in rundeck_framework_tokens %}
+{{ pair.user }}: {{ pair.key }}
+{% endfor %}


### PR DESCRIPTION
Hi @mrlesmithjr,

this patch will allow the user to configure a static token file for Rundeck. It will only trigger if the user configures user/key pairs within _rundeck_framework_tokens_.
[framework.properties documentation](http://rundeck.org/docs/administration/configuration-file-reference.html#framework.properties)

Let me know if this is okay for you or if I missed something.

Best regards

Jard
