### PR TITLE
allow optional configuration of RDECK_JVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ rundeck_ssh_key_type: omit # uses Ansible defaults
 rundeck_configs:
   - 'framework.properties'
   - 'rundeck-config.properties'
+rundeck_rdeck_jvm: '$RDECK_JVM -Xmx1024m -Xms256m -XX:MaxPermSize=256m -server'
 rundeck_mysql_backend: false
 rundeck_db_name: 'rundeck'
 rundeck_db_host: 'localhost'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ rundeck_configs:
   - 'framework.properties'
   - 'rundeck-config.properties'
   - 'profile'
+rundeck_rdeck_jvm: '$RDECK_JVM -Xmx1024m -Xms256m -XX:MaxPermSize=256m -server'
 rundeck_mysql_backend: false
 rundeck_db_name: 'rundeck'
 rundeck_db_host: 'localhost'

--- a/templates/etc/rundeck/profile.j2
+++ b/templates/etc/rundeck/profile.j2
@@ -46,7 +46,7 @@ export RDECK_JVM="-Drdeck.config=/etc/rundeck \
 #
 # Set min/max heap size
 #
-RDECK_JVM="$RDECK_JVM -Xmx1024m -Xms256m -XX:MaxPermSize=256m -server"
+RDECK_JVM="{{ rundeck_rdeck_jvm }}"
 #
 # SSL Configuration - Uncomment the following to enable.  Check SSL.properties for details.
 #


### PR DESCRIPTION
Hello @mrlesmithjr 

here comes the optional configuration of the _RDECK_JVM_ param in the Rundeck profiles file. It'll allow the user to manage custom JAVA params like giving Rundeck more memory.

Best regards and a happy new year (first PR this year)

Jard