### PR TITLE
optional deployment of aclpolicy files

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,67 @@ rundeck_root_dir: '/etc/rundeck'
 rundeck_vagrant_install: false  #defines if installing under Vagrant
 rundeck_version: '2.6.9-1'
 rundeck_install_ansible_version: '2.1.1.0'
+# rundeck_aclpolicies:
+#   - filename: /etc/myrules.aclpolicy # optional
+#     owner: 'rundeck'                 # optional
+#     group: 'rundeck'                 # optional
+#     mode: '0644'                     # optional
+#     content: |
+#       description: Admin project level access control. Applies to resources within a specific project.
+#       context:
+#         project: '.*' # all projects
+#       for:
+#         resource:
+#           - equals:
+#               kind: job
+#             allow: [create] # allow create jobs
+#           - equals:
+#               kind: node
+#             allow: [read,create,update,refresh] # allow refresh node sources
+#           - equals:
+#               kind: event
+#             allow: [read,create] # allow read/create events
+#         adhoc:
+#           - allow: [read,run,runAs,kill,killAs] # allow running/killing adhoc jobs
+#         job:
+#           - allow: [create,read,update,delete,run,runAs,kill,killAs] # allow create/read/write/delete/run/kill of all jobs
+#         node:
+#           - allow: [read,run] # allow read/run for nodes
+#       by:
+#         group: admin
+#       ---
+#       description: Admin Application level access control, applies to creating/deleting projects, admin of user profiles, viewing projects and reading system information.
+#       context:
+#         application: 'rundeck'
+#       for:
+#         resource:
+#           - equals:
+#               kind: project
+#             allow: [create] # allow create of projects
+#           - equals:
+#               kind: system
+#             allow: [read,enable_executions,disable_executions,admin] # allow read of system info, enable/disable all executions
+#           - equals:
+#               kind: system_acl
+#             allow: [read,create,update,delete,admin] # allow modifying system ACL files
+#           - equals:
+#               kind: user
+#             allow: [admin] # allow modify user profiles
+#         project:
+#           - match:
+#               name: '.*'
+#             allow: [read,import,export,configure,delete,admin] # allow full access of all projects or use 'admin'
+#         project_acl:
+#           - match:
+#               name: '.*'
+#             allow: [read,create,update,delete,admin] # allow modifying project-specific ACL files
+#         storage:
+#           - allow: [read,create,update,delete] # allow access for /ssh-key/* storage content
+
+#       by:
+#         group: admin
+
+
 ````
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ rundeck_vagrant_install: false  #defines if installing under Vagrant
 rundeck_version: '2.6.9-1'
 rundeck_install_ansible_version: '2.1.1.0'
 # rundeck_aclpolicies:
-#   - filename: /etc/myrules.aclpolicy # optional
+#   - filename: 'myrules'              # optional - will be placed as {{ rundeck_root_dir }}/{{ item.filename}}.aclpolicy
 #     owner: 'rundeck'                 # optional
 #     group: 'rundeck'                 # optional
 #     mode: '0644'                     # optional

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ rundeck_vagrant_install: false  #defines if installing under Vagrant
 rundeck_version: '2.6.9-1'
 rundeck_install_ansible_version: '2.1.1.0'
 # rundeck_aclfiles:
-#   - filename: /etc/myrules.aclpolicy # optional
+#   - filename: 'myrules'              # optional - will be placed as {{ rundeck_root_dir }}/{{ item.filename}}.aclpolicy
 #     owner: 'rundeck'                 # optional
 #     group: 'rundeck'                 # optional
 #     mode: '0644'                     # optional

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,3 +73,62 @@ rundeck_root_dir: '/etc/rundeck'
 rundeck_vagrant_install: false  #defines if installing under Vagrant
 rundeck_version: '2.6.9-1'
 rundeck_install_ansible_version: '2.1.1.0'
+# rundeck_aclfiles:
+#   - filename: /etc/myrules.aclpolicy # optional
+#     owner: 'rundeck'                 # optional
+#     group: 'rundeck'                 # optional
+#     mode: '0644'                     # optional
+#     content: |
+#       description: Admin project level access control. Applies to resources within a specific project.
+#       context:
+#         project: '.*' # all projects
+#       for:
+#         resource:
+#           - equals:
+#               kind: job
+#             allow: [create] # allow create jobs
+#           - equals:
+#               kind: node
+#             allow: [read,create,update,refresh] # allow refresh node sources
+#           - equals:
+#               kind: event
+#             allow: [read,create] # allow read/create events
+#         adhoc:
+#           - allow: [read,run,runAs,kill,killAs] # allow running/killing adhoc jobs
+#         job:
+#           - allow: [create,read,update,delete,run,runAs,kill,killAs] # allow create/read/write/delete/run/kill of all jobs
+#         node:
+#           - allow: [read,run] # allow read/run for nodes
+#       by:
+#         group: admin
+#       ---
+#       description: Admin Application level access control, applies to creating/deleting projects, admin of user profiles, viewing projects and reading system information.
+#       context:
+#         application: 'rundeck'
+#       for:
+#         resource:
+#           - equals:
+#               kind: project
+#             allow: [create] # allow create of projects
+#           - equals:
+#               kind: system
+#             allow: [read,enable_executions,disable_executions,admin] # allow read of system info, enable/disable all executions
+#           - equals:
+#               kind: system_acl
+#             allow: [read,create,update,delete,admin] # allow modifying system ACL files
+#           - equals:
+#               kind: user
+#             allow: [admin] # allow modify user profiles
+#         project:
+#           - match:
+#               name: '.*'
+#             allow: [read,import,export,configure,delete,admin] # allow full access of all projects or use 'admin'
+#         project_acl:
+#           - match:
+#               name: '.*'
+#             allow: [read,create,update,delete,admin] # allow modifying project-specific ACL files
+#         storage:
+#           - allow: [read,create,update,delete] # allow access for /ssh-key/* storage content
+
+#       by:
+#         group: admin

--- a/tasks/config_rundeck.yml
+++ b/tasks/config_rundeck.yml
@@ -47,3 +47,13 @@
     mode: '0640'
   notify: restart rundeck
   when: rundeck_framework_tokens is defined and rundeck_framework_tokens
+
+- name: COPY | deploy acl files
+  copy:
+    dest: "{{ rundeck_root_dir }}/{{ item.filename | default('custom_acls') }}"
+    content: "{{ item.content }}"
+    owner: "{{ item.owner | default('rundeck') }}"
+    group: "{{ item.group | default('rundeck') }}"
+    mode: "{{ item.mode | default('0640') }}"
+  with_items: "{{ rundeck_aclpolicies }}"
+  when: rundeck_aclpolicies is defined and rundeck_aclpolicies

--- a/tasks/config_rundeck.yml
+++ b/tasks/config_rundeck.yml
@@ -48,10 +48,10 @@
   notify: restart rundeck
   when: rundeck_framework_tokens is defined and rundeck_framework_tokens
 
-- name: COPY | deploy acl files
-  copy:
-    dest: "{{ rundeck_root_dir }}/{{ item.filename | default('custom_acls') }}"
-    content: "{{ item.content }}"
+- name: config_rundeck | deploy acl files
+  template:
+    src: "etc/rundeck/custom_acls.aclpolicy.j2"
+    dest: "{{ rundeck_root_dir }}/{{ item.filename | default('custom_acls') }}.aclpolicy"
     owner: "{{ item.owner | default('rundeck') }}"
     group: "{{ item.group | default('rundeck') }}"
     mode: "{{ item.mode | default('0640') }}"

--- a/templates/etc/rundeck/custom_acls.aclpolicy.j2
+++ b/templates/etc/rundeck/custom_acls.aclpolicy.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+{{ item.content }}


### PR DESCRIPTION
Hello @mrlesmithjr,

this PR allows the user to deploy custom acl policy files documented
[here](http://rundeck.org/docs/man5/aclpolicy.html) and [here](http://rundeck.org/docs/administration/access-control-policy.html).

If you know a nicer way to deploy a yaml dict to a yaml file on disk, please let me know. I played a bit with | to_nice_yaml but this filter killed the order (what's maybe no problem) and I also struggled with multiple dicts as well here. The copy attempt is quite simple and worked good for me.

Sorry for the long example's, I took them from the official documentation page to show how to deploy multiple definitions as well.

Let me know if you'd like to have some changes or improvements on that.

Best

Jard